### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 pyramid_fullauth
 ================
 
-.. image:: https://pypip.in/v/pyramid_fullauth/badge.png
+.. image:: https://img.shields.io/pypi/v/pyramid_fullauth.svg
     :target: https://pypi.python.org/pypi/pyramid_fullauth/
     :alt: Latest PyPI version
 
@@ -9,11 +9,11 @@ pyramid_fullauth
     :target: https://readthedocs.org/projects/pyramid_fullauth/?badge=v0.6.0
     :alt: Documentation Status
 
-.. image:: https://pypip.in/d/pyramid_fullauth/badge.png
+.. image:: https://img.shields.io/pypi/dm/pyramid_fullauth.svg
     :target: https://pypi.python.org/pypi/pyramid_fullauth/
     :alt: Number of PyPI downloads
 
-.. image:: https://pypip.in/wheel/pyramid_fullauth/badge.png
+.. image:: https://img.shields.io/pypi/wheel/pyramid_fullauth.svg
     :target: https://pypi.python.org/pypi/pyramid_fullauth/
     :alt: Wheel Status
 
@@ -21,7 +21,7 @@ pyramid_fullauth
     :target: https://pypi.python.org/pypi/pyramid_fullauth/
     :alt: Egg Status
 
-.. image:: https://pypip.in/license/pyramid_fullauth/badge.png
+.. image:: https://img.shields.io/pypi/l/pyramid_fullauth.svg
     :target: https://pypi.python.org/pypi/pyramid_fullauth/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyramid-fullauth))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyramid-fullauth`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.