### PR TITLE
Use html.unescape for Python 3.9 compatibility.

### DIFF
--- a/tests/unit/test_default_settings.py
+++ b/tests/unit/test_default_settings.py
@@ -12,4 +12,4 @@ def test_defaults(default_config):
     # csrf should be turned on by default
     assert default_config.registry['fullauth']['check_csrf'] is True
     # also hashalg should be anything but not md5 by default.
-    assert default_config.registry['fullauth']['authtkt']['hashalg'] is not 'md5'
+    assert default_config.registry['fullauth']['authtkt']['hashalg'] != 'md5'

--- a/tests/views/test_register.py
+++ b/tests/views/test_register.py
@@ -1,8 +1,6 @@
 """Registration related tests."""
-try:
-    from HTMLParser import HTMLParser
-except ImportError:
-    from html.parser import HTMLParser
+
+from html.parser import unescape
 
 import pytest
 import transaction
@@ -84,7 +82,7 @@ def test_register_error(db_session, default_app, email, password, confirm_passwo
     res = res.form.submit(extra_environ={'REMOTE_ADDR': '0.0.0.0'})
     transaction.commit()
 
-    assert error in HTMLParser().unescape(res.body.decode('unicode_escape'))
+    assert error in unescape(res.body.decode('unicode_escape'))
     assert db_session.query(User).count() == 0
 
 
@@ -113,7 +111,7 @@ def test_no_pass_confirm(db_session, nopassconfirm_app):
     res.form['password'] = DEFAULT_USER['password']
     res = res.form.submit(extra_environ={'REMOTE_ADDR': '0.0.0.0'})
 
-    assert 'Passwords don\'t match!' not in HTMLParser().unescape(res.body.decode('unicode_escape'))
+    assert 'Passwords don\'t match!' not in unescape(res.body.decode('unicode_escape'))
     transaction.commit()
 
     user = db_session.query(User).filter(User.email == DEFAULT_USER['email']).one()

--- a/tests/views/test_reset.py
+++ b/tests/views/test_reset.py
@@ -1,8 +1,6 @@
 """Reset password views."""
-try:
-    from HTMLParser import HTMLParser
-except ImportError:
-    from html.parser import HTMLParser
+
+from html.parser import unescape
 
 import transaction
 from pyramid.compat import text_type
@@ -87,7 +85,7 @@ def test_reset_proceed_wrong_confirm(user, db_session, default_app):
     res.form['confirm_password'] = NEW_PASSWORD + 'Typo'
     res = res.form.submit()
 
-    assert 'Error! Password doesn\'t match' in HTMLParser().unescape(res.body.decode('unicode_escape'))
+    assert 'Error! Password doesn\'t match' in unescape(res.body.decode('unicode_escape'))
 
 
 def test_reset_proceed_wrong_csrf(user, db_session, default_app):


### PR DESCRIPTION
Related to https://github.com/fizyk/pyramid_fullauth/issues/353

Fixes also below syntax warning : 

```
find . -iname '*.py' | xargs -P4 -I{} python3 -Wall -m py_compile {}  
./tests/unit/test_default_settings.py:15: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  assert default_config.registry['fullauth']['authtkt']['hashalg'] is not 'md5'
```