### PR TITLE
Add Python 3.15 to the CI - closes #941

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   tests:
     uses: fizyk/actions-reuse/.github/workflows/shared-tests-pytests.yml@bd825c06829614c809e87acac868a1143328a5b4 # v5.3.2
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
       pytest_opts: '-k "not mysql and not postgresql"'
       dependency-manager: 'uv'
     secrets:
@@ -21,7 +21,7 @@ jobs:
     needs: tests
     uses: fizyk/actions-reuse/.github/workflows/shared-tests-pytests.yml@bd825c06829614c809e87acac868a1143328a5b4 # v5.3.2
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
       pytest_opts: "-k postgresql"
       dependency-manager: 'uv'
     secrets:
@@ -30,7 +30,7 @@ jobs:
     needs: tests
     uses: fizyk/actions-reuse/.github/workflows/shared-tests-pytests.yml@bd825c06829614c809e87acac868a1143328a5b4 # v5.3.2
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
       pytest_opts: "-k mysql"
       dependency-manager: 'uv'
     secrets:

--- a/newsfragments/941.misc.rst
+++ b/newsfragments/941.misc.rst
@@ -1,0 +1,1 @@
+Add Python 3.15 to CI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added Python 3.15 to the automated test matrix, improving validation across supported Python versions.

- **Documentation**
  - Added a release note recording the expanded Python version coverage in continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->