### PR TITLE
Enable flake8-boolean-trap linter - closes #942

### DIFF
--- a/newsfragments/942.break.rst
+++ b/newsfragments/942.break.rst
@@ -1,0 +1,1 @@
+`remember_me` parameter on `login_perform` request method is now keyword only.

--- a/newsfragments/942.misc.rst
+++ b/newsfragments/942.misc.rst
@@ -1,0 +1,1 @@
+Enable `flake8-boolean-trap` linter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,11 +85,12 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E",  # pycodestyle
-    "F",  # pyflakes
-    "I",  # isort
-    "D",  # pydocstyle
-    "PL", # pylint
+    "E",   # pycodestyle
+    "F",   # pyflakes
+    "I",   # isort
+    "D",   # pydocstyle
+    "PL",  # pylint
+    "FBT", # flake8-boolean-trap
 ]
 
 [tool.ruff.lint.pylint]

--- a/pyramid_fullauth/request.py
+++ b/pyramid_fullauth/request.py
@@ -14,7 +14,7 @@ from sqlalchemy.sql.functions import func
 from pyramid_fullauth.models import User
 
 
-def login_perform(request, user, location=None, remember_me=False):
+def login_perform(request, user, location=None, *, remember_me=False):
     """Perform login action.
 
     :param pyramid.request.Request request: a request object

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -15,6 +15,7 @@ def authenticate(
     app,
     email=DEFAULT_USER["email"],
     password=DEFAULT_USER["password"],
+    *,
     remember=False,
     response_code=303,
 ):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `remember_me` option for login requests must now be provided as a keyword argument.

* **Chores**
  * Added boolean-trap linting checks to improve code quality and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->