### PR TITLE
docs: document root factory overriding

### DIFF
--- a/docs/source/customise.rst
+++ b/docs/source/customise.rst
@@ -12,6 +12,32 @@ To overwrite templates provided in ``pyramid_fullauth`` just add this line to yo
 You can overwrite all templates separately, all by a group, for more information, read:
 http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/assets.html#overriding-assets
 
+Root factory
+------------
+
+``pyramid_fullauth`` registers its own root factory
+(:class:`pyramid_fullauth.auth.BaseACLRootFactoryMixin`) automatically, so the
+ACL machinery is available out of the box. To use your own root factory
+instead (for example one that adds custom context classes), register it as a
+utility for ``pyramid.interfaces.IRootFactory`` *after* including the plugin:
+
+.. code-block:: python
+
+    config.include('pyramid_fullauth')
+    config.registry.registerUtility(MyRootFactory, IRootFactory)
+
+The plugin only registers its own factory when none is present, so registering
+yours afterwards guarantees it wins. ``MyRootFactory`` is free to inherit from
+:class:`pyramid_fullauth.auth.BaseACLRootFactoryMixin` to keep the built-in ACL
+behaviour::
+
+    from pyramid_fullauth.auth import BaseACLRootFactoryMixin
+
+    class MyRootFactory(BaseACLRootFactoryMixin):
+        def __init__(self, request):
+            super().__init__(request)
+            # custom context setup...
+
 Form inclusion
 --------------
 


### PR DESCRIPTION
## Summary

Per #78: documents how to override the root factory with your own implementation.

## Changes

- `docs/source/customise.rst`: new "Root factory" section explaining:
  - the plugin registers `BaseACLRootFactoryMixin` automatically when none is present
  - registering your own factory as a utility for `pyramid.interfaces.IRootFactory` **after** including the plugin guarantees it wins
  - how to keep built-in ACL behaviour by inheriting from `BaseACLRootFactoryMixin`

## Example covered

```python
config.include('pyramid_fullauth')
config.registry.registerUtility(MyRootFactory, IRootFactory)
```

This matches the approach the issue author found to work (`registerUtility`), now documented with the reasoning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on overriding the plugin’s default root factory.
  - Documented how to register a custom root factory and extend the provided base mixin.
  - Clarified that the default factory is only registered when no custom factory is already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->